### PR TITLE
DRY code

### DIFF
--- a/lib/base.rb
+++ b/lib/base.rb
@@ -17,7 +17,7 @@ class Base
   end
 
   def self.should_extract_from?(mod)
-    return false if (mod < Base || mod == Base || mod.is_a?(Base))
+    return false if module_is_a_base?(mod)
     return mod.is_a?(Module) && mod != Kernel
   end
 


### PR DESCRIPTION
Replace the logic with a method that uses the same logic.

Also, I was going to suggest using `mod <= Base` instead of `mod < Base || mod == Base`, but I recall you mentioning it on twitter so I figured there was some reason you decided against it.
