### PR TITLE
1.9 compatibility

### DIFF
--- a/lib/base.rb
+++ b/lib/base.rb
@@ -30,8 +30,8 @@ class Base
   end
 
   def self.call_method(object, name, args, block)
-    name_string = name.to_s
-
+    name_string = RUBY_VERSION.split(".")[0..1].join(".").to_f >= 1.9 ? name : name.to_s
+    
     all_modules.each do |mod|
       if mod.respond_to?(name)
         return mod.send name, *args, &block

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1,4 +1,4 @@
-require 'lib/base'
+require File.expand_path('lib/base')
 
 module NormalModule
   Something = 5


### PR DESCRIPTION
Module.instance_methods returns an array of symbols in Ruby 1.9, as opposed to 1.8 which returns an array of strings. This was causing all of the tests related to instance methods to fail on 1.9.

Speaking of tests, 1.9 doesn't like relative paths, so I've fixed the require statement at the top of the test file.
