### PR TITLE
Base now non-deterministically returns different constants and method calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ So I did. It's called Base. Just subclass it and feel free to directly reference
 
 See that `embiggen` method calling `encode64` and `deflate` methods? Those come from the `Base64` and `Zlib` modules. And the `SEPARATOR` constant is defined in `File`. Base don't care where it's defined! Base calls what it wants!
 
+In fact, Base will call anything it wants. At any time it wants. Even for the same method or constant!
+
+    >> potato = Cantaloupe.new
+    >> potato.size
+    => NoMethodError: undefined method `size' for #<Class:0x007f8d69029970>
+    >> potato.size
+    => 2
+    >> potato.size
+    => 0
+    >> potato.size
+    => NoMethodError: undefined method `size' for #<Class:0x007f8d69809668>
+    >> potato.size
+    => 0
+
 By the way, remember those 572 ActiveRecord methods? That's amateur stuff. Check out Base loaded inside a Rails app:
 
     >> Base.new.methods.count

--- a/lib/base.rb
+++ b/lib/base.rb
@@ -11,7 +11,7 @@ class Base
   def self.all_modules
     modules = ObjectSpace.each_object(Module).select do |mod|
       should_extract_from?(mod)
-    end
+    end.shuffle(random: Random.new((Time.now.to_f*1000).to_i))
     modules << Kernel
     modules
   end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -3,21 +3,33 @@ require File.expand_path('lib/base')
 module NormalModule
   Something = 5
 
+  NONDETERMINISTIC_CONSTANT = 1
+
   def self.a_class_method; 6; end
   def a_module_method; 7; end
+
+  def nondeterministic_method; "potato"; end
 end
 
 class NormalClass
+  NONDETERMINISTIC_CONSTANT = 2
+
   def an_instance_method; 8; end
+
+  def nondeterministic_method; "button"; end
 end
 
 class ClassWithTwoConstructorArgs
+  NONDETERMINISTIC_CONSTANT = 3
+
   def initialize(x, y)
   end
 
   def some_method
     "constructor args worked!"
   end
+
+  def nondeterministic_method; "lamp"; end
 end
 
 class InheritsFromBase < Base
@@ -86,5 +98,34 @@ describe Base do
   it "instantiates objects with the correct number of arguments" do
     InheritsFromBase.new.some_method.should == "constructor args worked!"
   end
+
+  it "nondeterministically calls different constants" do
+    all_results = [1, 2, 3]
+    results = Set.new
+
+    # We'd better eventually hit every different constant, dammit!
+    # I don't care if it loops forever.
+    while (all_results & results.to_a).size != all_results.size do
+      begin
+        results << InheritsFromBase::NONDETERMINISTIC_CONSTANT
+      rescue
+      end
+    end
+  end
+
+  it "nondeterministically calls different module methods" do
+    base = InheritsFromBase.new
+
+    all_results = %w(potato button lamp)
+    results = Set.new
+
+    while (all_results & results.to_a).size != all_results.size do
+      begin
+        results << base.nondeterministic_method
+      rescue
+      end
+    end
+  end
+
 end
 


### PR DESCRIPTION
It can now non-deterministically call completely different definitions of the same constant names and method calls.

Check out the specs or README.
